### PR TITLE
Updates to allow connecting to MongoDB Cloud Atlas

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -18,7 +18,7 @@ def create_app(environment, port):
     flask = Flask(__name__)
     flask.config.from_pyfile('config.py')
 
-    config_loader = ConfigLoader(verify=False)
+    config_loader = ConfigLoader(use_vault=False, verify=False)
     info = config_loader.load_application_info("./")
     config = config_loader.load_config("resources/", environment)
 

--- a/app/app.py
+++ b/app/app.py
@@ -18,7 +18,7 @@ def create_app(environment, port):
     flask = Flask(__name__)
     flask.config.from_pyfile('config.py')
 
-    config_loader = ConfigLoader(use_vault=False, verify=False)
+    config_loader = ConfigLoader(verify=False)
     info = config_loader.load_application_info("./")
     config = config_loader.load_config("resources/", environment)
 

--- a/app/mongo_connect.py
+++ b/app/mongo_connect.py
@@ -30,8 +30,12 @@ class MongoConnect:
     @staticmethod
     def build_uris(config):
         if config['mongo']['username'] and config['mongo']['password']:
-            return ['mongodb://' + config['mongo']['username'] + ':' + config['mongo']['password'] + '@' + db for db in
-                    config['mongo']['uris']]
+            uris = ','.join(config['mongo']['uris'])
+            ssl = 'ssl=' + str(config['mongo']['use_ssl']).lower() if config['mongo']['use_ssl'] else 'false'
+            authSource = '&authSource=' + str(config['mongo']['authSource']) if config['mongo']['authSource'] else ''
+            replicaSet = '&replicaSet=' + str(config['mongo']['replicaSet']) if config['mongo']['replicaSet'] else ''
+            return ['mongodb://' + config['mongo']['username'] + ':' + config['mongo']['password'] + \
+                '@' + uris + '/' + config['mongo']['database'] + '?' + ssl + replicaSet + authSource]
         else:
             return config['mongo']['uris']
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ humanize==0.5.1
 itsdangerous==0.24
 Jinja2==2.8
 MarkupSafe==0.23
-pymongo==3.2.1
+pymongo==3.6.1
 python-dateutil==2.4.2
 pytz==2015.7
 six==1.10.0

--- a/resources/local.yaml
+++ b/resources/local.yaml
@@ -27,7 +27,10 @@ mongo:
   password: ''
   uris:
     - localhost
+  use_ssl: true
   database: gatekeeper
+  replicaSet: ''
+  authSource: 'admin'
   services_collection: gatekeeper
   tickets_collection: tickets
   holidays_collection: holidays

--- a/resources/local.yaml
+++ b/resources/local.yaml
@@ -27,7 +27,7 @@ mongo:
   password: ''
   uris:
     - localhost
-  use_ssl: true
+  use_ssl: false
   database: gatekeeper
   replicaSet: ''
   authSource: 'admin'

--- a/resources/test.yaml
+++ b/resources/test.yaml
@@ -21,8 +21,9 @@ mongo:
   uris:
     - localhost
   database: testgatekeeper
+  use_ssl: false
   replicaSet: ''
-  authSource: 'admin'
+  authSource: ''
   services_collection: testgatekeeper
   tickets_collection: testtickets
   holidays_collection: testholidays

--- a/resources/test.yaml
+++ b/resources/test.yaml
@@ -21,6 +21,8 @@ mongo:
   uris:
     - localhost
   database: testgatekeeper
+  replicaSet: ''
+  authSource: 'admin'
   services_collection: testgatekeeper
   tickets_collection: testtickets
   holidays_collection: testholidays


### PR DESCRIPTION
The pull request includes a version upgrade of pymongo to allow SSL/TLS which is necessary for connecting to MongoDB Cloud Atlas (https://api.mongodb.com/python/current/atlas.html).

Building the URIs has also been extended to include a necessary `ssl` flag, a `replicaSet` and an authentication database `authSource`.

To retain existing functionality, the `ssl` flag is set to `false` by default. Not supplying a `replicaSet` value or `authSource` value in the config yamls will simply omit the options from the connection string. In this case, the connection string is identical aside from the included database option `/database`.

To summarize:
Old: `mongodb://username:password@hosts`
New: `mongodb://username:password@hosts/database?ssl&replicaSet&authSource`

The configuration files `local.yaml` and `test.yaml` have been updated to include the options required for Atlas.