### PR TITLE
Bug fix for edit-holiday issue

### DIFF
--- a/app/templates/edit_holidays_overlay.html
+++ b/app/templates/edit_holidays_overlay.html
@@ -39,14 +39,14 @@
             <small>Enter future holidays in the form of DD.MM.YYYY followed by an explanaion text e.g. 01.05.2018 1st May Bank Holiday, one entry one per line</small>
             <div id="holidays_list">
                 {% for holiday in holidays %}
-                    {{ holiday_entry(holiday, _external=False )}}
+                    {{ holiday_entry(holiday) }}
                 {% endfor %}
                 {%  if not holidays %}
-                    {{ holiday_entry(, _external=False )}}
+                    {{ holiday_entry() }}
                 {% endif %}
             </div>
             <div id="holiday_item_template" style="display:none;">
-                {{  holiday_entry(, _external=False )}}
+                {{  holiday_entry() }}
             </div>
 
             <div class="form-group">


### PR DESCRIPTION
The edit holiday button fails to open the menu due to a Find+Replace problem which has added `, _external=False` where it doesn't belong.

The problematic code has been removed.